### PR TITLE
CASSCPP-16 Revisit support for TLS 1.3

### DIFF
--- a/include/cassandra.h
+++ b/include/cassandra.h
@@ -634,7 +634,8 @@ typedef enum CassSslVerifyFlags_ {
 typedef enum CassSslTlsVersion_ {
   CASS_SSL_VERSION_TLS1   = 0x00,
   CASS_SSL_VERSION_TLS1_1 = 0x01,
-  CASS_SSL_VERSION_TLS1_2 = 0x02
+  CASS_SSL_VERSION_TLS1_2 = 0x02,
+  CASS_SSL_VERSION_TLS1_3 = 0x03
 } CassSslTlsVersion;
 
 typedef enum CassProtocolVersion_ {

--- a/src/ssl/ssl_openssl_impl.cpp
+++ b/src/ssl/ssl_openssl_impl.cpp
@@ -542,7 +542,7 @@ OpenSslContext::OpenSslContext()
   SSL_CTX_set_verify(ssl_ctx_, SSL_VERIFY_NONE, ssl_no_verify_callback);
 #if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
   // Limit to TLS 1.2 for now. TLS 1.3 has broken the handshake code.
-  SSL_CTX_set_max_proto_version(ssl_ctx_, TLS1_2_VERSION);
+  SSL_CTX_set_max_proto_version(ssl_ctx_, TLS1_3_VERSION);
 #endif
 #if DEBUG_SSL
   SSL_CTX_set_info_callback(ssl_ctx_, ssl_info_callback);

--- a/src/ssl/ssl_openssl_impl.cpp
+++ b/src/ssl/ssl_openssl_impl.cpp
@@ -541,7 +541,6 @@ OpenSslContext::OpenSslContext()
   SSL_CTX_set_cert_store(ssl_ctx_, trusted_store_);
   SSL_CTX_set_verify(ssl_ctx_, SSL_VERIFY_NONE, ssl_no_verify_callback);
 #if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
-  // Limit to TLS 1.2 for now. TLS 1.3 has broken the handshake code.
   SSL_CTX_set_max_proto_version(ssl_ctx_, TLS1_3_VERSION);
 #endif
 #if DEBUG_SSL
@@ -631,6 +630,9 @@ CassError OpenSslContext::set_min_protocol_version(CassSslTlsVersion min_version
       break;
     case CassSslTlsVersion::CASS_SSL_VERSION_TLS1_2:
       method = TLS1_2_VERSION;
+      break;
+    case CassSslTlsVersion::CASS_SSL_VERSION_TLS1_3:
+      method = TLS1_3_VERSION;
       break;
     default:
       // unsupported version

--- a/tests/src/unit/tests/test_socket.cpp
+++ b/tests/src/unit/tests/test_socket.cpp
@@ -431,7 +431,7 @@ TEST_F(SocketUnitTest, SslEnforceTlsVersion) {
 
   listen();
 
-  settings.ssl_context->set_min_protocol_version(CASS_SSL_VERSION_TLS1_2);
+  settings.ssl_context->set_min_protocol_version(CASS_SSL_VERSION_TLS1_3);
 
   bool is_error;
   SocketConnector::Ptr connector(new SocketConnector(


### PR DESCRIPTION
An experimental branch to enable support for TLS 1.3 in the driver.