### PR TITLE
Constify to fix build with OpenSSL 4

### DIFF
--- a/src/ssl/ssl_openssl_impl.cpp
+++ b/src/ssl/ssl_openssl_impl.cpp
@@ -284,19 +284,19 @@ public:
 
 private:
   static Result match_common_name_ipaddr(X509* cert, const String& address) {
-    X509_NAME* name = X509_get_subject_name(cert);
+    const X509_NAME* name = X509_get_subject_name(cert);
     if (name == NULL) {
       return INVALID_CERT;
     }
 
     int i = -1;
     while ((i = X509_NAME_get_index_by_NID(name, NID_commonName, i)) > 0) {
-      X509_NAME_ENTRY* name_entry = X509_NAME_get_entry(name, i);
+      const X509_NAME_ENTRY* name_entry = X509_NAME_get_entry(name, i);
       if (name_entry == NULL) {
         return INVALID_CERT;
       }
 
-      ASN1_STRING* str = X509_NAME_ENTRY_get_data(name_entry);
+      const ASN1_STRING* str = X509_NAME_ENTRY_get_data(name_entry);
       if (str == NULL) {
         return INVALID_CERT;
       }
@@ -315,19 +315,19 @@ private:
   }
 
   static Result match_common_name_dns(X509* cert, const String& hostname) {
-    X509_NAME* name = X509_get_subject_name(cert);
+    const X509_NAME* name = X509_get_subject_name(cert);
     if (name == NULL) {
       return INVALID_CERT;
     }
 
     int i = -1;
     while ((i = X509_NAME_get_index_by_NID(name, NID_commonName, i)) >= 0) {
-      X509_NAME_ENTRY* name_entry = X509_NAME_get_entry(name, i);
+      const X509_NAME_ENTRY* name_entry = X509_NAME_get_entry(name, i);
       if (name_entry == NULL) {
         return INVALID_CERT;
       }
 
-      ASN1_STRING* str = X509_NAME_ENTRY_get_data(name_entry);
+      const ASN1_STRING* str = X509_NAME_ENTRY_get_data(name_entry);
       if (str == NULL) {
         return INVALID_CERT;
       }


### PR DESCRIPTION
Without this patch, with OpenSSL 4 (on Fedora 45)

```
tity::Result OpenSslVerifyIdentity::match_common_name_ipaddr(X509*, const datastax::String&)’:
/builddir/build/BUILD/cassandra-cpp-driver-2.17.1-build/cpp-driver-e05897d72fdac08a212ed3136b7790232670e329/src/ssl/ssl_openssl_impl.cpp:285:44: error: invalid conversion from ‘const X509_NAME*’ {aka ‘const X509_name_st*’} to ‘X509_NAME*’ {aka ‘X509_name_st*’} [-Werror=permissive]
  285 |     X509_NAME* name = X509_get_subject_name(cert);
      |                       ~~~~~~~~~~~~~~~~~~~~~^~~~~~
      |                                            |
      |                                            const X509_NAME* {aka const X509_name_st*}
/builddir/build/BUILD/cassandra-cpp-driver-2.17.1-build/cpp-driver-e05897d72fdac08a212ed3136b7790232670e329/src/ssl/ssl_openssl_impl.cpp:292:56: error: invalid conversion from ‘const X509_NAME_ENTRY*’ {aka ‘const X509_name_entry_st*’} to ‘X509_NAME_ENTRY*’ {aka ‘X509_name_entry_st*’} [-Werror=permissive]
  292 |       X509_NAME_ENTRY* name_entry = X509_NAME_get_entry(name, i);
      |                                     ~~~~~~~~~~~~~~~~~~~^~~~~~~~~
      |                                                        |
      |                                                        const X509_NAME_ENTRY* {aka const X509_name_entry_st*}
/builddir/build/BUILD/cassandra-cpp-driver-2.17.1-build/cpp-driver-e05897d72fdac08a212ed3136b7790232670e329/src/ssl/ssl_openssl_impl.cpp:297:50: error: invalid conversion from ‘const ASN1_STRING*’ {aka ‘const asn1_string_st*’} to ‘ASN1_STRING*’ {aka ‘asn1_string_st*’} [-Werror=permissive]
  297 |       ASN1_STRING* str = X509_NAME_ENTRY_get_data(name_entry);
      |                          ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
      |                                                  |
      |                                                  const ASN1_STRING* {aka const asn1_string_st*}
/builddir/build/BUILD/cassandra-cpp-driver-2.17.1-build/cpp-driver-e05897d72fdac08a212ed3136b7790232670e329/src/ssl/ssl_openssl_impl.cpp: In static member function ‘static OpenSslVerifyIdentity::Result OpenSslVerifyIdentity::match_common_name_dns(X509*, const datastax::String&)’:
/builddir/build/BUILD/cassandra-cpp-driver-2.17.1-build/cpp-driver-e05897d72fdac08a212ed3136b7790232670e329/src/ssl/ssl_openssl_impl.cpp:316:44: error: invalid conversion from ‘const X509_NAME*’ {aka ‘const X509_name_st*’} to ‘X509_NAME*’ {aka ‘X509_name_st*’} [-Werror=permissive]
  316 |     X509_NAME* name = X509_get_subject_name(cert);
      |                       ~~~~~~~~~~~~~~~~~~~~~^~~~~~
      |                                            |
      |                                            const X509_NAME* {aka const X509_name_st*}
/builddir/build/BUILD/cassandra-cpp-driver-2.17.1-build/cpp-driver-e05897d72fdac08a212ed3136b7790232670e329/src/ssl/ssl_openssl_impl.cpp:323:56: error: invalid conversion from ‘const X509_NAME_ENTRY*’ {aka ‘const X509_name_entry_st*’} to ‘X509_NAME_ENTRY*’ {aka ‘X509_name_entry_st*’} [-Werror=permissive]
  323 |       X509_NAME_ENTRY* name_entry = X509_NAME_get_entry(name, i);
      |                                     ~~~~~~~~~~~~~~~~~~~^~~~~~~~~
      |                                                        |
      |                                                        const X509_NAME_ENTRY* {aka const X509_name_entry_st*}
/builddir/build/BUILD/cassandra-cpp-driver-2.17.1-build/cpp-driver-e05897d72fdac08a212ed3136b7790232670e329/src/ssl/ssl_openssl_impl.cpp:328:50: error: invalid conversion from ‘const ASN1_STRING*’ {aka ‘const asn1_string_st*’} to ‘ASN1_STRING*’ {aka ‘asn1_string_st*’} [-Werror=permissive]
  328 |       ASN1_STRING* str = X509_NAME_ENTRY_get_data(name_entry);
      |                          ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
      |                                                  |
      |                                                  const ASN1_STRING* {aka const asn1_string_st*}
cc1plus: all warnings being treated as errors

```